### PR TITLE
Disabling plugins, which metrics are not processed

### DIFF
--- a/collectd.conf
+++ b/collectd.conf
@@ -71,6 +71,8 @@ LoadPlugin syslog
 # Specify what features to activate.                                         #
 ##############################################################################
 
+# TODO: config plugins: disk, irq, interface, processes, disk, swap, memory
+
 LoadPlugin aggregation
 #LoadPlugin amqp
 #LoadPlugin apache
@@ -89,7 +91,7 @@ LoadPlugin cpu
 #LoadPlugin curl_xml
 #LoadPlugin dbi
 LoadPlugin df
-LoadPlugin disk
+#LoadPlugin disk
 #LoadPlugin dns
 #LoadPlugin email
 LoadPlugin entropy
@@ -99,11 +101,11 @@ LoadPlugin entropy
 #LoadPlugin fscache
 #LoadPlugin gmond
 #LoadPlugin hddtemp
-LoadPlugin interface
+#LoadPlugin interface
 #LoadPlugin ipmi
 #LoadPlugin iptables
 #LoadPlugin ipvs
-LoadPlugin irq
+#LoadPlugin irq
 LoadPlugin java
 #LoadPlugin libvirt
 LoadPlugin load
@@ -114,7 +116,7 @@ LoadPlugin match_regex
 #LoadPlugin md
 #LoadPlugin memcachec
 #LoadPlugin memcached
-LoadPlugin memory
+#LoadPlugin memory
 #LoadPlugin modbus
 #LoadPlugin multimeter
 #LoadPlugin mysql
@@ -136,7 +138,7 @@ LoadPlugin memory
 #LoadPlugin ping
 #LoadPlugin postgresql
 #LoadPlugin powerdns
-LoadPlugin processes
+#LoadPlugin processes
 #LoadPlugin protocols
 #<LoadPlugin python>
 #	Globals true
@@ -147,7 +149,7 @@ LoadPlugin processes
 #LoadPlugin serial
 #LoadPlugin snmp
 #LoadPlugin statsd
-LoadPlugin swap
+#LoadPlugin swap
 #LoadPlugin table
 #LoadPlugin tail
 #LoadPlugin tail_csv
@@ -206,7 +208,7 @@ LoadPlugin users
 #</Plugin>
 
 <Plugin "cpu">
-   ReportByState true
+   ReportByState false
    ReportByCpu true
    ValuesPercentage true
 </Plugin>


### PR DESCRIPTION
- Disabling some plugins, as we don't process their output anywhere and they send quite a big amount of metrics

- Also, configured CPU plugin to aggregate it's metrics into one, active, metric instead of system, idle,user, etc.